### PR TITLE
Explorer UX improvements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Features:
   - Explorer web UI and CLI both automatically capitalizes the keys in records now.
   - Update Records link added to Explorer name page, which automatically preloads data for user to update, including most recent record set.
   - Name page now creates links to other resources where appropriate for some record types. For example, WEB records now render as a link to the site.
+  - MOTD records now have a little but of decorative quoting.
+  - The Search bar strips whitespace.
 
 Bugs:
   - Indexer will not longer stop randomly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Features:
   - Explorer now links to a name instead of a NSID. This simply makes it easier for a something to be bookmarked, even after a transfer.
+  - Explorer web UI and CLI both automatically capitalizes the keys in records now.
 
 Bugs:
   - Indexer will not longer stop randomly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.1
+
+Bugs:
+  - Indexer will not longer stop randomly.
+
+## 0.1.0
+
+- Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Features:
   - Explorer now links to a name instead of a NSID. This simply makes it easier for a something to be bookmarked, even after a transfer.
   - Explorer web UI and CLI both automatically capitalizes the keys in records now.
+  - Update Records link added to Explorer name page, which automatically preloads data for user to update, including most recent record set.
 
 Bugs:
   - Indexer will not longer stop randomly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Features:
   - Explorer now links to a name instead of a NSID. This simply makes it easier for a something to be bookmarked, even after a transfer.
   - Explorer web UI and CLI both automatically capitalizes the keys in records now.
   - Update Records link added to Explorer name page, which automatically preloads data for user to update, including most recent record set.
+  - Name page now creates links to other resources where appropriate for some record types. For example, WEB records now render as a link to the site.
 
 Bugs:
   - Indexer will not longer stop randomly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Bugs:
 
 Other:
   - Added `WEB` record type to spec.
+  - Changes "New Records" to "Update Records" everywhere.
+  - More detailed help instructions.
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 Features:
   - Explorer now links to a name instead of a NSID. This simply makes it easier for a something to be bookmarked, even after a transfer.
   - Explorer web UI and CLI both automatically capitalizes the keys in records now.
-  - Update Records link added to Explorer name page, which automatically preloads data for user to update, including most recent record set.
-  - Name page now creates links to other resources where appropriate for some record types. For example, WEB records now render as a link to the site.
-  - MOTD records now have a little but of decorative quoting.
+  - Name page: Update Records link added, which automatically preloads data for user to update, including most recent record set.
+  - Name page: Blockhash and Txid link to block explorer mempool.space.
+  - Name page: Links for different record types. For example, `WEB` record links to actual webpage.
+  - Name page: MOTD records now have a little but of decorative quoting.
   - The Search bar strips whitespace.
 
 Bugs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.1.1
 
+Features:
+  - Explorer now links to a name instead of a NSID. This simply makes it easier for a something to be bookmarked, even after a transfer.
+
 Bugs:
   - Indexer will not longer stop randomly.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 Bugs:
   - Indexer will not longer stop randomly.
 
+Other:
+  - Added `WEB` record type to spec.
+
 ## 0.1.0
 
 - Initial release.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -77,13 +77,14 @@ In the future, a protocol addition may even include the ability for indexers to 
 
 There are no restrictions on key/value pairs, but they are recommended by convention for the key names to be uppercase. It would be useful to establish some standard keys by convention for simple interoperability. Here are suggested keys:
 
-| KEY NAME | DESCRIPTION                      |
-|----------|----------------------------------|
-| IP4      | IPv4 address for a website       |
-| IP6      | IPv6 address for a website       |
-| DNS      | DNS name for a website           |
-| NPUB     | Nostr NPUB                       |
-| EMAIL    | Owner email address              |
-| MOTD     | A general message from the owner |
+| KEY NAME | DESCRIPTION                                               |
+|----------|-----------------------------------------------------------|
+| `IP4`    | IPv4 address for a website                                |
+| `IP6`    | IPv6 address for a website                                |
+| `DNS`    | Alias for DNS hostname                                    |
+| `NPUB`   | Nostr NPUB                                                |
+| `EMAIL`  | Owner email address                                       |
+| `MOTD`   | A general message from the owner                          |
+| `WEB`    | Full link for website (not necessarily the same as `DNS`) |
 
 Others may arise later by addition or general public acceptance. The above listed are not required, but if the owner wishes to include any of this data in their records, it is recommended to use the above keys.

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
             }
         },
         config::Subcommand::Name(name) => subcommands::name(&config, name).await?,
-        config::Subcommand::Index => subcommands::index(&config, &pool).await?,
+        config::Subcommand::Index => subcommands::index(&config).await?,
         config::Subcommand::Server(server) => subcommands::start(&config, &pool, server).await?,
     }
 

--- a/src/subcommands/index/events/records.rs
+++ b/src/subcommands/index/events/records.rs
@@ -64,7 +64,9 @@ async fn latest_events(
         .since(index_height.into());
 
     let (_keys, client) = config.nostr_random_client().await?;
-    Ok(client
+    let events = client
         .get_events_of(vec![filter], Some(Duration::from_secs(10)))
-        .await?)
+        .await?;
+    client.disconnect().await?;
+    Ok(events)
 }

--- a/src/subcommands/index/events/transfer.rs
+++ b/src/subcommands/index/events/transfer.rs
@@ -34,9 +34,11 @@ async fn latest_events(
         .since(index_height.into());
 
     let (_keys, client) = config.nostr_random_client().await?;
-    Ok(client
+    let events = client
         .get_events_of(vec![filter], Some(Duration::from_secs(10)))
-        .await?)
+        .await?;
+    client.disconnect().await?;
+    Ok(events)
 }
 
 async fn save_event(pool: &SqlitePool, ed: EventData) -> anyhow::Result<()> {

--- a/src/subcommands/index/mod.rs
+++ b/src/subcommands/index/mod.rs
@@ -9,12 +9,13 @@ mod blockchain;
 mod events;
 mod owners;
 
-pub async fn index(config: &Config, pool: &SqlitePool) -> anyhow::Result<()> {
-    blockchain::index(config, pool).await?;
-    events::records(config, pool).await?;
-    events::transfer(config, pool).await?;
-    owners::reindex(pool).await?;
+pub async fn index(config: &Config) -> anyhow::Result<()> {
+    let pool = config.sqlite().await?;
+    blockchain::index(config, &pool).await?;
+    events::records(config, &pool).await?;
+    events::transfer(config, &pool).await?;
+    owners::reindex(&pool).await?;
 
-    db::save_event(pool, "index", "").await?;
+    db::save_event(&pool, "index", "").await?;
     Ok(())
 }

--- a/src/subcommands/server.rs
+++ b/src/subcommands/server.rs
@@ -169,10 +169,11 @@ mod site {
         let conn = state.pool;
         let last_index_time = db::last_index_time(&conn).await?;
         let last_index_time = util::format_time(last_index_time)?;
+        let q = query.q.map(|s| s.trim().to_string());
 
         Ok(ExplorerTemplate {
-            q: query.q.clone().unwrap_or_default(),
-            names: db::top_level_names(&conn, query.q).await?,
+            q: q.clone().unwrap_or_default(),
+            names: db::top_level_names(&conn, q).await?,
             last_index_time,
         })
     }

--- a/src/subcommands/server.rs
+++ b/src/subcommands/server.rs
@@ -100,7 +100,10 @@ async fn indexer(config: Config, server: ServerSubcommand, pool: SqlitePool) -> 
     interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     loop {
-        subcommands::index(&config, &pool).await?;
+        match subcommands::index(&config, &pool).await {
+            Ok(_) => {}
+            Err(err) => log::error!("Indexing error: {}", err),
+        }
         interval.tick().await;
     }
     Ok(())

--- a/src/subcommands/server.rs
+++ b/src/subcommands/server.rs
@@ -54,7 +54,7 @@ pub async fn start(
     server: &ServerSubcommand,
 ) -> anyhow::Result<()> {
     if !server.without_indexer {
-        let _indexer = tokio::spawn(indexer(config.clone(), server.clone(), conn.clone()));
+        let _indexer = tokio::spawn(indexer(config.clone(), server.clone()));
     }
     let mut app = Router::new();
 
@@ -95,12 +95,12 @@ pub async fn start(
     Ok(())
 }
 
-async fn indexer(config: Config, server: ServerSubcommand, pool: SqlitePool) -> anyhow::Result<()> {
+async fn indexer(config: Config, server: ServerSubcommand) -> anyhow::Result<()> {
     let mut interval = interval(Duration::from_secs(config.server_indexer_delay()));
     interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     loop {
-        match subcommands::index(&config, &pool).await {
+        match subcommands::index(&config).await {
             Ok(_) => {}
             Err(err) => log::error!("Indexing error: {}", err),
         }

--- a/src/subcommands/server.rs
+++ b/src/subcommands/server.rs
@@ -65,8 +65,8 @@ pub async fn start(
             .route("/explorer/:nsid", get(site::explore_nsid))
             .route("/newname", get(site::new_name_form))
             .route("/newname", post(site::new_name_submit))
-            .route("/newrecords", get(site::new_records_form))
-            .route("/newrecords", post(site::new_records_submit));
+            .route("/updaterecords", get(site::new_records_form))
+            .route("/updaterecords", post(site::new_records_submit));
     }
 
     if !server.without_api {
@@ -271,7 +271,7 @@ mod site {
     }
 
     #[derive(askama::Template)]
-    #[template(path = "newrecords.html")]
+    #[template(path = "updaterecords.html")]
     pub struct NewRecordsTemplate {
         name: String,
         pubkey: String,

--- a/src/util/keyval.rs
+++ b/src/util/keyval.rs
@@ -18,6 +18,6 @@ impl FromStr for KeyVal {
         let (key, val) = s
             .split_once('=')
             .ok_or_else(|| anyhow!("Invalid key=value"))?;
-        Ok(KeyVal(key.to_string(), val.to_string()))
+        Ok(KeyVal(key.to_string().to_uppercase(), val.to_string()))
     }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,7 +22,7 @@
       <a href="/">Home</a>
       <a href="/explorer">Explorer</a>
       <a href="/newname">New Name</a>
-      <a href="/newrecords">Update Records</a>
+      <a href="/updaterecords">Update Records</a>
     </nav>
   </header>
 

--- a/templates/explorer.html
+++ b/templates/explorer.html
@@ -20,7 +20,7 @@
     {% else %}
     <ul>
       {% for name in names %}
-      <li><a href="/explorer/{{ name.0 }}">{{ name.1 }}</a></li>
+      <li><a href="/explorer/{{ name.1 }}">{{ name.1 }}</a></li>
       {% endfor %}
     </ul>
     {% endif %}

--- a/templates/newname.html
+++ b/templates/newname.html
@@ -9,7 +9,7 @@
   <pre id="psbt">{{ psbt }}</pre>
   <button id="copy">Copy</button>
 
-  <p>After signing and transmitting the transaction, <a href="/newrecords?name={{ name }}&pubkey={{ pubkey }}">setup your records</a> for the indexer to property index your new name.</p>
+  <p>After signing and transmitting the transaction, <a href="/updaterecords?name={{ name }}&pubkey={{ pubkey }}">setup your records</a> for the indexer to property index your new name.</p>
 
   <script>
     let btn = document.getElementById('copy');
@@ -33,17 +33,22 @@
   </p>
 
   <p>
-    The indexer waits for {{confirmations}} confirmations for all names.
+    The indexer waits for {{confirmations}} block confirmations.
+  </p>
+
+  <p>
+    In order for the indexer to properly index your name, you also need to send your records after you broadcast your transaction!
+    You can comeback anytime and click on <a href="/updaterecords">Update Records</a> in the navigation menu.
   </p>
   
   <form action="/newname" method="POST">
-    <p><strong>Input</strong></p>
+    <h2>Input</h2>
     <p>
       <label for="psbt">PSBT</label>
       <textarea name="psbt" id="psbt" cols="30" rows="10">{{ psbt }}</textarea>
     </p>
 
-    <p><strong>Output</strong></p>
+    <h2>Output</h2>
 
     <p>
       <label for="name">Name</label>

--- a/templates/nsid.html
+++ b/templates/nsid.html
@@ -10,7 +10,7 @@
     <tbody>
       <tr>
         <td>Blockhash</td>
-        <td>{{ blockhash }}</td>
+        <td><a href="https://mempool.space/block/{{blockhash}}">{{ blockhash }}</a></td>
       </tr>
       <tr>
         <td>Block Height</td>
@@ -18,7 +18,7 @@
       </tr>
       <tr>
         <td>Txid</td>
-        <td>{{ txid }}</td>
+        <td><a href="https://mempool.space/tx/{{ txid }}">{{ txid }}</a></td>
       </tr>
       <tr>
         <td>Vout</td>

--- a/templates/nsid.html
+++ b/templates/nsid.html
@@ -63,6 +63,10 @@
         <td><a href="https://snort.social/p/{{ records[key] }}" target="_blank">{{ records[key] }}</a></td>
         {% else if key == "TWITTER" %}
         <td><a href="https://twitter.com/{{ records[key] }}" target="_blank">{{ records[key] }}</a></td>
+        {% else if key == "MOTD" %}
+        <td>
+          <i>"{{ records[key] }}"</i>
+        </td>
         {% else %}
         <td>{{ records[key] }}</td>
         {% endif %}

--- a/templates/nsid.html
+++ b/templates/nsid.html
@@ -39,6 +39,8 @@
 
   <h3>Records</h3>
 
+  <p><small><a href="/updaterecords?name={{ name }}&pubkey={{ pubkey }}">Update Records</a></small></p>
+
   {% if records.is_empty() %}
   <p>No records found.</p>
   {% else %}

--- a/templates/nsid.html
+++ b/templates/nsid.html
@@ -57,7 +57,11 @@
       {% for key in record_keys %}
       <tr>
         <td>{{ key }}</td>
+        {% if key == "WEB" %}
+        <td><a href="{{ records[key] }}">{{ records[key]}}</a></td>
+        {% else %}
         <td>{{ records[key] }}</td>
+        {% endif %}
       </tr>
       {% endfor %}
     </tbody>

--- a/templates/nsid.html
+++ b/templates/nsid.html
@@ -58,7 +58,11 @@
       <tr>
         <td>{{ key }}</td>
         {% if key == "WEB" %}
-        <td><a href="{{ records[key] }}">{{ records[key]}}</a></td>
+        <td><a href="{{ records[key] }}" target="_blank">{{ records[key] }}</a></td>
+        {% else if key == "NPUB" %}
+        <td><a href="https://snort.social/p/{{ records[key] }}" target="_blank">{{ records[key] }}</a></td>
+        {% else if key == "TWITTER" %}
+        <td><a href="https://twitter.com/{{ records[key] }}" target="_blank">{{ records[key] }}</a></td>
         {% else %}
         <td>{{ records[key] }}</td>
         {% endif %}

--- a/templates/updaterecords.html
+++ b/templates/updaterecords.html
@@ -62,7 +62,7 @@
       <label for="records">
         Enter records below. Each record should be on its own line, with a key and value separated by an equal (=) sign.
       </label>
-      <textarea name="records" id="records" cols="30" rows="10">KEY=value</textarea>
+      <textarea name="records" id="records" cols="30" rows="10">{{ records }}</textarea>
     </p>
 
     {% include "pubkey.html" %}

--- a/templates/updaterecords.html
+++ b/templates/updaterecords.html
@@ -4,7 +4,7 @@
 <script src="https://unpkg.com/nostr-tools/lib/nostr.bundle.js"></script>
 
 <main id="main" data-relays="{{relays|json}}">
-  <h1>New Records</h1>
+  <h1>Update Records</h1>
   {% if !unsigned_event.is_empty() %}
   
   <p>The following event was created. You can use a NIP-07 browser extension to sign and broadcast this event, using the same keypair that was used to register the name on the blockchain.</p>
@@ -52,7 +52,7 @@
 
   {% else %}
   
-  <form action="newrecords" method="post">
+  <form action="updaterecords" method="post">
     <p>
       <label for="name">Name</label>
       <input type="text" id="name" name="name" value="{{ name }}">


### PR DESCRIPTION
## 0.1.1

Features:
  - Explorer now links to a name instead of a NSID. This simply makes it easier for a something to be bookmarked, even after a transfer.
  - Explorer web UI and CLI both automatically capitalizes the keys in records now.
  - Name page: Update Records link added, which automatically preloads data for user to update, including most recent record set.
  - Name page: Blockhash and Txid link to block explorer mempool.space.
  - Name page: Links for different record types. For example, `WEB` record links to actual webpage.
  - Name page: MOTD records now have a little but of decorative quoting.
  - The Search bar strips whitespace.

Bugs:
  - Indexer will not longer stop randomly.

Other:
  - Added `WEB` record type to spec.
  - Changes "New Records" to "Update Records" everywhere.
  - More detailed help instructions.