### PR TITLE
NOM-04: Relay-published indexes

### DIFF
--- a/example.nomen.toml
+++ b/example.nomen.toml
@@ -3,6 +3,11 @@ data = "nomen.db"
 [nostr]
 relays = ["wss://relay.damus.io"]
 
+# Per NOM-04 spec: Publish indexes to relays
+secret = "nsec1..."
+publish = true
+well-known = true
+
 [server]
 bind = "0.0.0.0:8080"
 without_explorer = false

--- a/nomen/src/config/cfg.rs
+++ b/nomen/src/config/cfg.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use anyhow::bail;
 use bitcoin::Network;
 use nostr_sdk::{
     prelude::{FromSkStr, ToBech32},
@@ -84,6 +85,25 @@ impl Config {
             Network::Signet => 143_500,
             _ => 0,
         }
+    }
+
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.missing_secret_key() {
+            bail!("Config: Secret key required for relay publising");
+        }
+        Ok(())
+    }
+
+    fn missing_secret_key(&self) -> bool {
+        (self.publish_index() || self.well_known()) && self.file.nostr.secret.is_none()
+    }
+
+    fn publish_index(&self) -> bool {
+        self.file.nostr.publish.unwrap_or_default()
+    }
+
+    fn well_known(&self) -> bool {
+        self.file.nostr.well_known.unwrap_or_default()
     }
 
     fn rpc_cookie(&self) -> Option<PathBuf> {

--- a/nomen/src/config/config_file.rs
+++ b/nomen/src/config/config_file.rs
@@ -54,8 +54,8 @@ impl RpcConfig {
 pub struct NostrConfig {
     pub relays: Option<Vec<String>>,
     pub secret: Option<Nsec>,
-    pub publish: bool,
-    pub well_known: bool,
+    pub publish: Option<bool>,
+    pub well_known: Option<bool>,
 }
 impl NostrConfig {
     fn example() -> NostrConfig {
@@ -65,8 +65,8 @@ impl NostrConfig {
                 .secret_key()
                 .ok()
                 .map(std::convert::Into::into),
-            publish: true,
-            well_known: true,
+            publish: Some(true),
+            well_known: Some(true),
         }
     }
 }

--- a/nomen/src/config/config_file.rs
+++ b/nomen/src/config/config_file.rs
@@ -1,7 +1,10 @@
 use std::path::PathBuf;
 
 use bitcoin::Network;
+use nostr_sdk::Keys;
 use serde::{Deserialize, Serialize};
+
+use crate::util::Nsec;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ServerConfig {
@@ -50,11 +53,20 @@ impl RpcConfig {
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct NostrConfig {
     pub relays: Option<Vec<String>>,
+    pub secret: Option<Nsec>,
+    pub publish: bool,
+    pub well_known: bool,
 }
 impl NostrConfig {
     fn example() -> NostrConfig {
         NostrConfig {
             relays: Some(vec!["wss://relay.damus.io".into()]),
+            secret: Keys::generate()
+                .secret_key()
+                .ok()
+                .map(std::convert::Into::into),
+            publish: true,
+            well_known: true,
         }
     }
 }

--- a/nomen/src/db/mod.rs
+++ b/nomen/src/db/mod.rs
@@ -13,9 +13,10 @@ use sqlx::{Sqlite, SqlitePool};
 mod index;
 mod name;
 mod raw;
+pub mod relay_index;
 pub mod stats;
 
-static MIGRATIONS: [&str; 14] = [
+static MIGRATIONS: [&str; 15] = [
     "CREATE TABLE event_log (id INTEGER PRIMARY KEY, created_at, type, data);",
     "CREATE TABLE index_height (blockheight INTEGER PRIMARY KEY, blockhash);",
     "CREATE TABLE raw_blockchain (id INTEGER PRIMARY KEY, blockhash, txid, blocktime, blockheight, txheight, vout, data, indexed_at);",
@@ -49,6 +50,7 @@ static MIGRATIONS: [&str; 14] = [
     "CREATE TABLE name_events (name, fingerprint, nsid, pubkey, created_at, event_id, records, indexed_at, raw_event);",
     "CREATE UNIQUE INDEX name_events_unique_idx ON name_events(name, pubkey);",
     "CREATE INDEX name_events_created_at_idx ON name_events(created_at);",
+    "CREATE TABLE relay_index_queue (name);"
 ];
 
 pub async fn initialize(config: &Config) -> anyhow::Result<SqlitePool> {

--- a/nomen/src/main.rs
+++ b/nomen/src/main.rs
@@ -52,6 +52,7 @@ fn parse_config() -> anyhow::Result<Config> {
     };
 
     let config = Config::new(cli, file);
+    config.validate()?;
 
     tracing::debug!("Config loaded: {config:?}");
 

--- a/nomen/src/subcommands/index/blockchain.rs
+++ b/nomen/src/subcommands/index/blockchain.rs
@@ -289,6 +289,7 @@ async fn index_output(conn: &SqlitePool, index: BlockchainIndex) -> anyhow::Resu
                     }
                 }
             }
+            db::relay_index::queue(conn, name).await?;
         }
     } else {
         db::insert_blockchain_index(conn, &index).await?;

--- a/nomen/src/subcommands/index/events/mod.rs
+++ b/nomen/src/subcommands/index/events/mod.rs
@@ -1,5 +1,6 @@
 mod event_data;
 mod records;
+pub mod relay_index;
 
 pub use event_data::*;
 pub use records::*;

--- a/nomen/src/subcommands/index/events/records.rs
+++ b/nomen/src/subcommands/index/events/records.rs
@@ -49,6 +49,8 @@ async fn save_event(pool: &SqlitePool, ed: EventData) -> anyhow::Result<()> {
 
     db::update_v0_index(pool, name.as_ref(), &pubkey, calculated_nsid).await?;
 
+    db::relay_index::queue(pool, name.as_ref()).await?;
+
     Ok(())
 }
 

--- a/nomen/src/subcommands/index/events/records.rs
+++ b/nomen/src/subcommands/index/events/records.rs
@@ -56,10 +56,10 @@ async fn latest_events(
     config: &Config,
     pool: &sqlx::Pool<sqlx::Sqlite>,
 ) -> anyhow::Result<Vec<Event>> {
-    let index_height = db::last_records_time(pool).await?;
+    let records_time = db::last_records_time(pool).await? + 1;
     let filter = Filter::new()
         .kind(NameKind::Name.into())
-        .since(index_height.into());
+        .since(records_time.into());
 
     let (_keys, client) = config.nostr_random_client().await?;
     let events = client

--- a/nomen/src/subcommands/index/events/relay_index.rs
+++ b/nomen/src/subcommands/index/events/relay_index.rs
@@ -1,0 +1,65 @@
+use std::collections::HashMap;
+
+use nostr_sdk::{EventBuilder, Keys, Tag};
+use secp256k1::SecretKey;
+use serde::Serialize;
+use sqlx::SqlitePool;
+
+use crate::{
+    config::Config,
+    db::{self, relay_index::Name},
+};
+
+pub async fn publish(config: &Config, pool: &SqlitePool) -> anyhow::Result<()> {
+    if !config.publish_index() {
+        return Ok(());
+    }
+    let sk: SecretKey = config
+        .secret_key()
+        .expect("Missing config validation for secret")
+        .into();
+    let keys = Keys::new(sk);
+    let client = config.nostr_keys_client(&keys).await?;
+    tracing::info!("Publishing relay index.");
+    let names = db::relay_index::fetch_all(pool).await?;
+
+    send_event(names, keys, &client).await?;
+
+    db::relay_index::clear(pool).await?;
+    client.disconnect().await.ok();
+    Ok(())
+}
+
+async fn send_event(
+    names: Vec<Name>,
+    keys: Keys,
+    client: &nostr_sdk::Client,
+) -> Result<(), anyhow::Error> {
+    for name in names {
+        let records: HashMap<String, String> = serde_json::from_str(&name.records)?;
+        let content = Content {
+            name: name.name.clone(),
+            pubkey: name.pubkey,
+            records,
+        };
+        let content_serialize = serde_json::to_string(&content)?;
+        let event = EventBuilder::new(
+            nostr_sdk::Kind::ParameterizedReplaceable(38301),
+            content_serialize,
+            &[Tag::Identifier(name.name.clone())],
+        )
+        .to_event(&keys)?;
+
+        if client.send_event(event).await.is_err() {
+            tracing::error!("Unable to broadcast event during relay index publish");
+        }
+    }
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct Content {
+    name: String,
+    pubkey: String,
+    records: HashMap<String, String>,
+}

--- a/nomen/src/subcommands/index/mod.rs
+++ b/nomen/src/subcommands/index/mod.rs
@@ -7,6 +7,7 @@ pub async fn index(config: &Config) -> anyhow::Result<()> {
     let pool = config.sqlite().await?;
     blockchain::index(config, &pool).await?;
     events::records(config, &pool).await?;
+    events::relay_index::publish(config, &pool).await?;
 
     db::save_event(&pool, "index", "").await?;
     Ok(())

--- a/nomen/src/subcommands/server/mod.rs
+++ b/nomen/src/subcommands/server/mod.rs
@@ -64,6 +64,10 @@ pub async fn start(config: &Config, conn: &SqlitePool) -> anyhow::Result<()> {
             .route("/stats", get(explorer::index_stats));
     }
 
+    if config.well_known() {
+        app = app.route("/.well-known/nomen.json", get(explorer::well_known::nomen));
+    }
+
     if config.api() {
         let api_router = Router::new()
             .route("/names", get(api::names))

--- a/nomen/src/util/mod.rs
+++ b/nomen/src/util/mod.rs
@@ -1,7 +1,9 @@
 mod keyval;
+mod nsec;
 mod pubkey;
 
 pub use keyval::*;
+pub use nsec::*;
 pub use pubkey::*;
 
 use time::{macros::format_description, OffsetDateTime};

--- a/nomen/src/util/mod.rs
+++ b/nomen/src/util/mod.rs
@@ -1,10 +1,10 @@
 mod keyval;
+mod npub;
 mod nsec;
-mod pubkey;
 
 pub use keyval::*;
+pub use npub::*;
 pub use nsec::*;
-pub use pubkey::*;
 
 use time::{macros::format_description, OffsetDateTime};
 

--- a/nomen/src/util/npub.rs
+++ b/nomen/src/util/npub.rs
@@ -6,24 +6,24 @@ use serde::Serialize;
 
 #[derive(Debug, Clone, Copy, Serialize, serde_with::DeserializeFromStr)]
 
-pub struct Pubkey(XOnlyPublicKey);
+pub struct Npub(XOnlyPublicKey);
 
-impl AsRef<XOnlyPublicKey> for Pubkey {
+impl AsRef<XOnlyPublicKey> for Npub {
     fn as_ref(&self) -> &XOnlyPublicKey {
         &self.0
     }
 }
 
-impl FromStr for Pubkey {
+impl FromStr for Npub {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let keys = Keys::from_pk_str(s)?;
-        Ok(Pubkey(keys.public_key()))
+        Ok(Npub(keys.public_key()))
     }
 }
 
-impl Display for Pubkey {
+impl Display for Npub {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.0.to_string())
     }
@@ -35,14 +35,14 @@ mod tests {
 
     #[test]
     fn test_npub() {
-        let _pubkey: Pubkey = "npub1u50q2x85utgcgqrmv607crvmk8x3k2nvyun84dxlj6034kajje0s2cm3r0"
+        let _pubkey: Npub = "npub1u50q2x85utgcgqrmv607crvmk8x3k2nvyun84dxlj6034kajje0s2cm3r0"
             .parse()
             .unwrap();
     }
 
     #[test]
     fn test_hex() {
-        let _pubkey: Pubkey = "e51e0518f4e2d184007b669fec0d9bb1cd1b2a6c27267ab4df969f1adbb2965f"
+        let _pubkey: Npub = "e51e0518f4e2d184007b669fec0d9bb1cd1b2a6c27267ab4df969f1adbb2965f"
             .parse()
             .unwrap();
     }

--- a/nomen/src/util/nsec.rs
+++ b/nomen/src/util/nsec.rs
@@ -35,6 +35,12 @@ impl From<SecretKey> for Nsec {
     }
 }
 
+impl From<Nsec> for SecretKey {
+    fn from(value: Nsec) -> Self {
+        value.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/nomen/src/util/nsec.rs
+++ b/nomen/src/util/nsec.rs
@@ -1,0 +1,55 @@
+use std::{fmt::Display, str::FromStr};
+
+use nostr_sdk::{prelude::FromSkStr, Keys, ToBech32};
+use secp256k1::SecretKey;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, Serialize, serde_with::DeserializeFromStr)]
+
+pub struct Nsec(SecretKey);
+
+impl AsRef<SecretKey> for Nsec {
+    fn as_ref(&self) -> &SecretKey {
+        &self.0
+    }
+}
+
+impl FromStr for Nsec {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let keys = Keys::from_sk_str(s)?;
+        Ok(Nsec(keys.secret_key().expect("Secret key required")))
+    }
+}
+
+impl Display for Nsec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0.to_bech32().expect("Unable to format as bech32"))
+    }
+}
+
+impl From<SecretKey> for Nsec {
+    fn from(value: SecretKey) -> Self {
+        Nsec(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nsec() {
+        let _nsec: Nsec = "nsec18meshnlpsyl6qpq4jkwh9hks3v4uprp44las83akz6xfndc9tx2q646wuk"
+            .parse()
+            .unwrap();
+    }
+
+    #[test]
+    fn test_hex() {
+        let _nsec: Nsec = "3ef30bcfe1813fa00415959d72ded08b2bc08c35affb03c7b6168c99b7055994"
+            .parse()
+            .unwrap();
+    }
+}


### PR DESCRIPTION
This adds support for the pending [NOM-04](https://github.com/ursuscamp/noms/pull/1) specification, which standardizes how relays can publish their name data to Nostr relays.