### PR TITLE
fix: Re-download record events after reindex

### DIFF
--- a/nomen/src/db/index.rs
+++ b/nomen/src/db/index.rs
@@ -188,5 +188,8 @@ pub async fn reindex(
         .bind(blockheight)
         .execute(conn)
         .await?;
+    sqlx::query("DELETE FROM name_events;")
+        .execute(conn)
+        .await?;
     Ok(())
 }


### PR DESCRIPTION
This truncates the name_events table on reindex, which will cause the record events to be redownloaded after a reindex operations.

This may need to be made more efficient later if the protocol grows.