### PR TITLE
Rebroadcast republish

### DIFF
--- a/nomen/src/db/relay_index.rs
+++ b/nomen/src/db/relay_index.rs
@@ -18,13 +18,25 @@ pub struct Name {
     pub records: String,
 }
 
-pub async fn fetch_all(
+pub async fn fetch_all_queued(
     conn: impl sqlx::Executor<'_, Database = Sqlite> + Copy,
 ) -> anyhow::Result<Vec<Name>> {
     let results = sqlx::query_as::<_, Name>(
         "SELECT vnr.name, vnr.pubkey, COALESCE(vnr.records, '{}') as records
         FROM valid_names_records_vw vnr
         JOIN relay_index_queue riq ON vnr.name = riq.name;",
+    )
+    .fetch_all(conn)
+    .await?;
+    Ok(results)
+}
+
+pub async fn fetch_all(
+    conn: impl sqlx::Executor<'_, Database = Sqlite> + Copy,
+) -> anyhow::Result<Vec<Name>> {
+    let results = sqlx::query_as::<_, Name>(
+        "SELECT vnr.name, vnr.pubkey, COALESCE(vnr.records, '{}') as records
+        FROM valid_names_records_vw vnr;",
     )
     .fetch_all(conn)
     .await?;

--- a/nomen/src/subcommands/index/mod.rs
+++ b/nomen/src/subcommands/index/mod.rs
@@ -7,7 +7,7 @@ pub async fn index(config: &Config) -> anyhow::Result<()> {
     let pool = config.sqlite().await?;
     blockchain::index(config, &pool).await?;
     events::records(config, &pool).await?;
-    events::relay_index::publish(config, &pool).await?;
+    events::relay_index::publish(config, &pool, true).await?;
 
     db::event_log::save(&pool, "index", "").await?;
     Ok(())

--- a/nomen/src/subcommands/mod.rs
+++ b/nomen/src/subcommands/mod.rs
@@ -75,5 +75,5 @@ pub(crate) async fn rebroadcast(config: &Config, pool: &SqlitePool) -> anyhow::R
 
 pub(crate) async fn publish(config: &Config, pool: &SqlitePool) -> anyhow::Result<()> {
     println!("Publishing full relay index");
-    index::events::relay_index::publish(config, pool).await
+    index::events::relay_index::publish(config, pool, false).await
 }


### PR DESCRIPTION
Bugfix where the publish command uses (probably empty) relay index queue. The publish command should not use the queue, it should republish all